### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -14,7 +14,7 @@
     "@reasonableconsulting/oolong",
     "@reasonableconsulting/compare",
     "@reasonableconsulting/bs-victory",
-    "@aantron/repromise"
+    "reason-promise"
   ],
   "namespace": true,
   "reason": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "bundle-level": "browserify --standalone level --exclude react-native level.js | derequire > level.dist.js"
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.0",
     "@glennsl/bs-json": "^4.0.0",
     "@reasonableconsulting/bs-victory": "0.0.0",
     "@reasonableconsulting/compare": "0.0.0",
@@ -28,6 +27,7 @@
     "react-dom": "^16.5.2",
     "react-native": "0.60.4",
     "react-native-vector-icons": "^4.6.0",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.7.0",
     "victory": "^30.4.0"
   },
@@ -39,7 +39,7 @@
     "asyncstorage-down": "^4.0.1",
     "babel-jest": "^24.1.0",
     "browserify": "^16.2.2",
-    "bs-platform": "^5.0.6",
+    "bs-platform": "^7.0.1",
     "derequire": "^2.0.6",
     "jest": "^24.1.0",
     "level-packager": "^4.0.1",

--- a/src/Application.re
+++ b/src/Application.re
@@ -85,7 +85,7 @@ let create = () => {
   let loadDeck = (~key=?, deckName, hash, _, self) =>
     /* self.Oolong.send(NavigateTo(Loading)); */
     Deck.loadFromHash(~key?, ~name=deckName, hash)
-    |> Repromise.wait(result =>
+    ->Promise.get(result =>
          switch (result) {
          | Belt.Result.Ok(deck) => self.Oolong.send(DeckLoaded(deck))
          | Belt.Result.Error(msg) => Js.log(msg)
@@ -105,7 +105,7 @@ let create = () => {
   let saveDeck = self =>
     /* TODO: Indicator for saving deck (if this takes long/can fail) */
     PrivateDeck.persist(self.Oolong.state.deck)
-    |> Repromise.wait(result =>
+    ->Promise.get(result =>
          switch (result) {
          | Belt.Result.Ok(deck) =>
            if (Deck.isEmpty(deck)) {
@@ -164,7 +164,7 @@ let create = () => {
           },
           self =>
             Deck.loadFromHash(~name=?deckName, hash)
-            |> Repromise.wait(result =>
+            ->Promise.get(result =>
                  switch (result) {
                  | Belt.Result.Ok(deck) =>
                    self.Oolong.send(DeckRestored(deck))

--- a/src/Database.re
+++ b/src/Database.re
@@ -10,9 +10,9 @@ module Levelup = {
   [@bs.module "../level.dist.js"]
   external namespace: (t('a), string, ~options: options=?, unit) => t('b) =
     "";
-  [@bs.send] external put: (t('a), string, 'a) => Repromise.t(unit) = "";
-  [@bs.send] external get: (t('a), string) => Repromise.t('a) = "";
-  [@bs.send] external del: (t('a), string) => Repromise.t('a) = "";
+  [@bs.send] external put: (t('a), string, 'a) => Promise.t(unit) = "";
+  [@bs.send] external get: (t('a), string) => Promise.t('a) = "";
+  [@bs.send] external del: (t('a), string) => Promise.t('a) = "";
   [@bs.send] external createReadStream: (t('a), unit) => stream = "";
   [@bs.send] external createValueStream: (t('a), unit) => stream = "";
 
@@ -43,22 +43,22 @@ module Decks = {
     let now = Js.Date.make();
     let key = Js.Date.toISOString(now);
     let record = toJS(~key, ~name, ~hash, ~createdAt=now, ~updatedAt=now);
-    Levelup.put(db, key, record) |> Repromise.map(_ => Belt.Result.Ok(key));
+    Levelup.put(db, key, record)->Promise.map(_ => Belt.Result.Ok(key));
   };
 
   let update = (~key, ~name, ~hash) => {
     /* TODO: Fix created at */
     let now = Js.Date.make();
     let record = toJS(~key, ~name, ~hash, ~createdAt=now, ~updatedAt=now);
-    Levelup.put(db, key, record) |> Repromise.map(_ => Belt.Result.Ok(key));
+    Levelup.put(db, key, record)->Promise.map(_ => Belt.Result.Ok(key));
   };
 
   let delete = (~key) =>
-    Levelup.del(db, key) |> Repromise.map(_ => Belt.Result.Ok(key));
+    Levelup.del(db, key)->Promise.map(_ => Belt.Result.Ok(key));
 
   let getAll = () => {
     let records = Belt.MutableQueue.make();
-    let (promise, resolve) = Repromise.make();
+    let (promise, resolve) = Promise.pending();
 
     let onData = record => Belt.MutableQueue.add(records, record);
     let onEnd = _ => {

--- a/src/Deck.re
+++ b/src/Deck.re
@@ -459,18 +459,18 @@ query CardList($uids: [String!]!) {
 let decode = json => json |> Json.Decode.dict(Json.Decode.int);
 
 let loadFromHash = (~key=?, ~name=?, hash) => {
-  let (result, resolve) = Repromise.make();
+  let (result, resolve) = Promise.pending();
 
   MyFetch.fetch(
     "https://metax.toyboat.net/decodeDeck.php?output=metaxdb&hash=" ++ hash,
   )
-  |> Repromise.map(result =>
+  ->Promise.map(result =>
        switch (result) {
        | Belt.Result.Ok(data) => decode(data)->Belt.Result.Ok
        | Belt.Result.Error(msg) => Belt.Result.Error(msg)
        }
      )
-  |> Repromise.wait(result =>
+  ->Promise.get(result =>
        switch (result) {
        | Belt.Result.Ok(dict) =>
          let uids =

--- a/src/MyFetch.re
+++ b/src/MyFetch.re
@@ -1,15 +1,15 @@
 type response;
-[@bs.val] external fetch_: string => Repromise.t(response) = "fetch";
+[@bs.val] external fetch_: string => Promise.t(response) = "fetch";
 
 [@bs.get] external ok: response => bool = "";
-[@bs.send] external json: response => Repromise.t(Js.Json.t) = "";
+[@bs.send] external json: response => Promise.t(Js.Json.t) = "";
 
 let fetch = url =>
   fetch_(url)
-  |> Repromise.andThen(resp =>
+  ->Promise.flatMap(resp =>
        if (ok(resp)) {
-         json(resp) |> Repromise.map(json => Belt.Result.Ok(json));
+         json(resp)->Promise.map(json => Belt.Result.Ok(json));
        } else {
-         Repromise.resolved(Belt.Result.Error("Response not okay"));
+         Promise.resolved(Belt.Result.Error("Response not okay"));
        }
      );

--- a/src/PrivateDeck.re
+++ b/src/PrivateDeck.re
@@ -12,8 +12,8 @@ let getAll = () => {
   };
 
   Database.Decks.getAll()
-  |> Repromise.map(records => Belt.Array.map(records, toPrivateDeck))
-  |> Repromise.map(decks => Belt.Result.Ok(decks));
+  ->Promise.map(records => Belt.Array.map(records, toPrivateDeck))
+  ->Promise.map(decks => Belt.Result.Ok(decks));
 };
 
 let persist = deck => {
@@ -24,25 +24,25 @@ let persist = deck => {
   switch (maybeKey, maybeName, maybeHash) {
   | (Some(key), _, None) =>
     Database.Decks.delete(~key)
-    |> Repromise.map(
+    ->Promise.map(
          fun
          | Belt.Result.Ok(_key) => Belt.Result.Ok(Deck.empty)
          | Belt.Result.Error(msg) => Belt.Result.Error(msg),
        )
   | (None, Some(name), Some(hash)) =>
     Database.Decks.insert(~name, ~hash)
-    |> Repromise.map(
+    ->Promise.map(
          fun
          | Belt.Result.Ok(key) => Belt.Result.Ok(Deck.keySet(deck, key))
          | Belt.Result.Error(msg) => Belt.Result.Error(msg),
        )
   | (Some(key), Some(name), Some(hash)) =>
     Database.Decks.update(~key, ~name, ~hash)
-    |> Repromise.map(
+    ->Promise.map(
          fun
          | Belt.Result.Ok(_key) => Belt.Result.Ok(deck)
          | Belt.Result.Error(msg) => Belt.Result.Error(msg),
        )
-  | _ => Repromise.resolved(Belt.Result.Error("Invalid configuration"))
+  | _ => Promise.resolved(Belt.Result.Error("Invalid configuration"))
   };
 };

--- a/src/PublicDeck.re
+++ b/src/PublicDeck.re
@@ -13,10 +13,10 @@ let decode = json => {
 };
 
 let getAll = _ => {
-  let (result, resolve) = Repromise.make();
+  let (result, resolve) = Promise.pending();
 
   MyFetch.fetch("https://metax.toyboat.net/netdecker.php?json=true")
-  |> Repromise.wait(result =>
+  ->Promise.get(result =>
        switch (result) {
        | Belt.Result.Ok(data) =>
          switch (Js.Json.decodeArray(data)) {

--- a/src/page/Page_SavedDecks.re
+++ b/src/page/Page_SavedDecks.re
@@ -75,7 +75,7 @@ let toListItems = (privateDecks, publicDecks) => {
 
 let getPrivateDecks = () =>
   PrivateDeck.getAll()
-  |> Repromise.map(result =>
+  ->Promise.map(result =>
        switch (result) {
        | Belt.Result.Ok(decks) =>
          Belt.Array.map(decks, toPrivate)->Belt.Result.Ok
@@ -84,7 +84,7 @@ let getPrivateDecks = () =>
      );
 let getPublicDecks = () =>
   PublicDeck.getAll()
-  |> Repromise.map(result =>
+  ->Promise.map(result =>
        switch (result) {
        | Belt.Result.Ok(decks) =>
          Belt.Array.map(decks, toPublic)->Belt.Result.Ok
@@ -97,8 +97,8 @@ let getDecks = self => {
 
   let public = getPublicDecks();
 
-  Repromise.all([private, public])
-  |> Repromise.map(results =>
+  Promise.all([private, public])
+  ->Promise.map(results =>
        switch (results) {
        | [private, public] =>
          let privateDecks = Belt.Result.getWithDefault(private, [||]);
@@ -110,7 +110,7 @@ let getDecks = self => {
        | _ => Belt.Result.Error("Invalid results")
        }
      )
-  |> Repromise.wait(result =>
+  ->Promise.get(result =>
        switch (result) {
        | Belt.Result.Ok(data) => self.ReasonReact.send(StoreData(data))
        | Belt.Result.Error(msg) => Js.log(msg)


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.